### PR TITLE
Added multiline support and some cleanup done

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,4 +27,4 @@ Clone the repository into your custom oh-my-zsh themes directory:
 $ git clone https://github.com/reobin/typewritten.git $ZSH_CUSTOM/themes/typewritten
 ```
 
-Set **ZSH_THEME="typewritten/typewritten"** in your **.zshrc**.
+Set ``ZSH_THEME="typewritten/typewritten"`` in your ``.zshrc``.

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -21,6 +21,10 @@ precmd_functions+=(_fix_cursor)
 
 # Set the left prompt
 if [[ -z ${TYPEWRITTEN_MULTILINE} ]]; then
+  # Set the left prompt (singleline)
+  local user_prompt='%(?,%{$fg[blue]%}> ,%{$fg[red]%}> )'
+  PROMPT="${user_prompt}"
+else
   # Distinction between normal and root user
   if [[ ${UID} -eq 0 ]]; then
     local user_host='%{$fg[red]%}%n@%m %{$reset_color%}'
@@ -31,11 +35,7 @@ if [[ -z ${TYPEWRITTEN_MULTILINE} ]]; then
   fi
   # Set the left prompt (multiline)
   PROMPT="${user_host}
-  ${user_prompt}"
-else
-  # Set the left prompt (singleline)
-  local user_prompt='%(?,%{$fg[blue]%}> ,%{$fg[red]%}> )'
-  PROMPT="${user_prompt}"
+${user_prompt}"
 fi
 
 # Set the return code

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -1,3 +1,5 @@
+# Typewritten theme for oh-my-zsh
+
 # Set the git prompt
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$reset_color%}->%{$fg[magenta]%} "
 ZSH_THEME_GIT_PROMPT_SUFFIX=""
@@ -19,20 +21,21 @@ _fix_cursor() {
 }
 precmd_functions+=(_fix_cursor)
 
-# Set the left prompt
+# Distinction between single and multiline prompt based on
+# TYPEWRITTEN_MULTILINE variable
 if [[ -z ${TYPEWRITTEN_MULTILINE} ]]; then
-  # Set the left prompt (singleline)
+  # Distinction between normal and root user
   local user_prompt='%(?,%{$fg[blue]%}> ,%{$fg[red]%}> )'
+
+  # Set the left prompt (singleline)
   PROMPT="${user_prompt}"
 else
+  # Get current user and hostname
+  local user_host='%{$fg[magenta]%}%n@%m %{$reset_color%}'
+
   # Distinction between normal and root user
-  if [[ ${UID} -eq 0 ]]; then
-    local user_host='%{$fg[red]%}%n@%m %{$reset_color%}'
-    local user_prompt='%{$fg[red]%}$ %{$reset_color%}'
-  else
-    local user_host='%{$fg[magenta]%}%n@%m %{$reset_color%}'
-    local user_prompt='%{$fg[blue]%}> %{$reset_color%}'
-  fi
+  local user_prompt='%(?,%{$fg[blue]%}> ,%{$fg[red]%}$ )'
+
   # Set the left prompt (multiline)
   PROMPT="${user_host}
 ${user_prompt}"

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -1,12 +1,14 @@
-PROMPT='%{$fg[blue]%}> '
+# set left prompt
+PROMPT='%{$fg[blue]%}%n@%m > '
 
+# set right prompt
 RPROMPT='%{$fg[magenta]%}%c$(git_prompt_info)%{$reset_color%} $(git_prompt_status)%{$reset_color%}'
 
+# set git prompt
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$reset_color%}->%{$fg[magenta]%} "
 ZSH_THEME_GIT_PROMPT_SUFFIX=""
 ZSH_THEME_GIT_PROMPT_DIRTY=""
 ZSH_THEME_GIT_PROMPT_CLEAN=""
-
 ZSH_THEME_GIT_PROMPT_ADDED="%{$fg_bold[cyan]%} +"
 ZSH_THEME_GIT_PROMPT_MODIFIED="%{$fg_bold[yellow]%} !"
 ZSH_THEME_GIT_PROMPT_DELETED="%{$fg_bold[red]%} —"
@@ -17,3 +19,8 @@ ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[yellow]%} $"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{$fg_bold[blue]%} •|"
 ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg_bold[blue]%} |•"
 
+# Prompt cursor fix when exiting vim
+_fix_cursor() {
+  echo -ne '\e[3 q'
+}
+precmd_functions+=(_fix_cursor)

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -25,7 +25,7 @@ ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg_bold[blue]%} |•"
 local git_info='$(git_prompt_info) $(git_prompt_status)%{$reset_color%}'
 
 # current user and hostname
-local user_host='%{$fg[blue]%}%n@%m %{$reset_color%}'
+local user_host='%F{180}%}%n@%m %{$reset_color%}'
 
 # default: blue, if return code other than 0: red
 local prompt='%(?,%{$fg[blue]%}> ,%{$fg[red]%}> )'

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -1,4 +1,4 @@
-# Distinguish between normal and root user
+# Distinction between normal and root user
 if [[ ${UID} -eq 0 ]]; then
     local user_host='%{$fg[red]%}%n@%m %{$reset_color%}'
     local user_symbol='%{$fg[red]%}$ %{$reset_color%}'
@@ -7,14 +7,22 @@ else
     local user_symbol='%{$fg[blue]%}> %{$reset_color%}'
 fi
 
-# set left prompt (multiline)
-PROMPT="${user_host}
-${user_symbol}"
+# Set the return code
+local return_code='%(?,,%{$fg[magenta]%}RC=%?%{$reset_color%})'
 
-# set right prompt
-RPROMPT='%{$fg[magenta]%}%c$(git_prompt_info)%{$reset_color%} $(git_prompt_status)%{$reset_color%}'
+# Set directory
+local directory_path='%{$fg[magenta]%}%c%{$reset_color%}'
 
-# set git prompt
+# Set git repository
+local git_info='%{$fg[magenta]%}$(git_prompt_info)%{$reset_color%} $(git_prompt_status)%{$reset_color%}'
+
+# Fix prompt cursor when exiting vim
+_fix_cursor() {
+  echo -ne '\e[3 q'
+}
+precmd_functions+=(_fix_cursor)
+
+# Set the git prompt
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$reset_color%}->%{$fg[magenta]%} "
 ZSH_THEME_GIT_PROMPT_SUFFIX=""
 ZSH_THEME_GIT_PROMPT_DIRTY=""
@@ -29,8 +37,11 @@ ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[yellow]%} $"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{$fg_bold[blue]%} •|"
 ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg_bold[blue]%} |•"
 
-# Prompt cursor fix when exiting vim
-_fix_cursor() {
-  echo -ne '\e[3 q'
-}
-precmd_functions+=(_fix_cursor)
+# Set the left prompt (multiline)
+PROMPT="${user_host}
+${user_symbol}"
+
+# Set the right prompt
+RPROMPT="${directory_path}"
+RPROMPT+="${git_info}"
+RPROMPT+=" ${return_code}"

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -1,5 +1,15 @@
-# set left prompt
-PROMPT='%{$fg[blue]%}%n@%m > '
+# Distinguish between normal and root user
+if [[ ${UID} -eq 0 ]]; then
+    local user_host='%{$fg[red]%}%n@%m %{$reset_color%}'
+    local user_symbol='%{$fg[red]%}$ %{$reset_color%}'
+else
+    local user_host='%{$fg[magenta]%}%n@%m %{$reset_color%}'
+    local user_symbol='%{$fg[blue]%}> %{$reset_color%}'
+fi
+
+# set left prompt (multiline)
+PROMPT="${user_host}
+${user_symbol}"
 
 # set right prompt
 RPROMPT='%{$fg[magenta]%}%c$(git_prompt_info)%{$reset_color%} $(git_prompt_status)%{$reset_color%}'

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -24,11 +24,11 @@ ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg_bold[blue]%} |•"
 # git status display
 local git_info='$(git_prompt_info) $(git_prompt_status)%{$reset_color%}'
 
+# current user and hostname
+local user_host='%{$fg[blue]%}%n@%m %{$reset_color%}'
+
 # default: blue, if return code other than 0: red
 local prompt='%(?,%{$fg[blue]%}> ,%{$fg[red]%}> )'
-
-# current user and hostname
-local user_host='%{$fg[magenta]%}%n@%m %{$reset_color%}'
 
 # current directory display
 local directory_path='%{$fg[magenta]%}%c'

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -40,11 +40,11 @@ local return_code=' %(?,,%{$fg[magenta]%}RC=%?%{$reset_color%})'
 # activate multiline with TYPEWRITTEN_MULTILINE=true
 if [[ -z ${TYPEWRITTEN_MULTILINE} ]]; then
   # left prompt definition (singleline)
-  PROMPT="${user_prompt}"
+  PROMPT="${prompt}"
 else
   # left prompt definition (multiline)
   PROMPT="${user_host}
-${user_prompt}"
+${prompt}"
 fi
 
 # right prompt definition


### PR DESCRIPTION
I've added multiline support to "typewritten" with user and host as I need this for the distinction of target nodes when I use multiple terminals. It can be activated by setting the TYPEWRITTEN_MULTILINE=true in .zshrc.