### PR TITLE
Feature/cursor option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Leaves all the room for what's important.
   - ``|•``    — ahead of remote branch;
 - Prompt color changes to red when an error return code is\
 returned and code is displayed on the right
+- Cursor customization
 - Multiline support
 - Prompt cursor fix when exiting vim
 
@@ -36,10 +37,17 @@ ln -s "$ZSH_CUSTOM/themes/typewritten/typewritten.zsh-theme" "$ZSH_CUSTOM/themes
 
 Set ``ZSH_THEME="typewritten/typewritten"`` in your ``.zshrc``.
 
+## Cursor option
+Default cursor is ``underscore``, but there is two more options: ``beam`` and ``block``.
+They are both configured by adding the `TYPEWRITTEN_CURSOR` zsh variable to your ``.zshrc``:
+```shell
+export TYPEWRITTEN_CURSOR="beam"
+```
+
 ## Multiline option
 Multiline is now supported thanms to [@thbe](https://github.com/thbe). Add this option to your ``.zshrc``:
 ```shell
-TYPEWRITTEN_MULTILINE=true
+export TYPEWRITTEN_MULTILINE=true
 ```
 
 ## Screenshots

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -53,7 +53,13 @@ RPROMPT+="${git_info}"
 RPROMPT+="${return_code}"
 
 # prompt cursor fix when exiting vim
+local cursor="\e[3 q"
+if [ "$TYPEWRITTEN_CURSOR" = "block" ]; then
+  cursor="\e[1 q"
+elif [ "$TYPEWRITTEN_CURSOR" = "beam" ]; then
+  cursor="\e[5 q"
+fi
 _fix_cursor() {
-  echo -ne "\e[3 q"
+  echo -ne "${cursor}"
 }
 precmd_functions+=(_fix_cursor)


### PR DESCRIPTION
Closes #2 

3 options are available: `underscore` (default), `beam`, and `block`

`beam` and `block` are configurable by adding `TYPEWRITTEN_CURSOR` option to `.zshrc`:
```shell
export TYPEWRITTEN_CURSOR="beam"
```