### PR TITLE
feat: Add option to customize the prompt symbol

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,9 @@ Leaves all the room for what's important.
 
 
 ## Features
+- Prompt layout customization
+- Prompt symbol customization
+- Cursor customization
 - Current directory
 - Current git branch
 - Git status indicators:
@@ -19,8 +22,6 @@ Leaves all the room for what's important.
   - ``#``     &nbsp; — unmerged change(s);
   - ``•|``    — behind of remote branch;
   - ``|•``    — ahead of remote branch;
-- Prompt layout customization
-- Cursor customization
 - Prompt color changes to red when an error return code is\
 returned and code is displayed on the right
 - Prompt cursor fix when exiting vim
@@ -59,6 +60,13 @@ user@host
 **singleline verbose**
 ```shell
 user@host >
+```
+
+
+### Prompt symbol
+Default prompt symbole is ``>``. It is entirely customizable with the ``TYPEWRITTEN_SYMBOL`` zsh variable. For example, one could set the symbol as `$` by adding the following line to his ``.zshrc``:
+```shell
+export TYPEWRITTEN_SYMBOL="$"
 ```
 
 

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -29,7 +29,15 @@ local user_host='%{$fg[yellow]%}%n%{$reset_color%}@%{$fg[yellow]%}%m %{$reset_co
 
 # default: blue, if return code other than 0: red
 local prompt_color="%(?,%{$fg[blue]%},%{$fg[red]%})"
-local prompt='${prompt_color}> %{$reset_color%}'
+
+# default: >
+local prompt_symbol=">"
+
+if [ ! -z "$TYPEWRITTEN_SYMBOL" ]; then
+    prompt_symbol="$TYPEWRITTEN_SYMBOL"
+fi
+
+local prompt='${prompt_color}${prompt_symbol} %{$reset_color%}'
 
 # current directory display
 local directory_path='%{$fg[magenta]%}%c'


### PR DESCRIPTION
Closes #10 

Option is driven by the ``TYPEWRITTEN_SYMBOL`` zsh variable and will replace the ``>`` prompt symbol by whatever its value is.