### PR TITLE
feat: Add right prompt fix option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,24 @@ export TYPEWRITTEN_CURSOR="beam"
 ```
 
 
+### Right prompt prefix
+By default, there is no prefix. Right prompt is made of the current directory and it's git repo info.\
+A prefix can be added with the `TYPEWRITTEN_RIGHT_PROMPT_PREFIX` option.\
+For example, by using:
+```shell
+export TYPEWRITTEN_RIGHT_PROMPT_PREFIX="# "
+```
+My right prompt:
+```shell
+> ls              directory -> master (git info)
+```
+Would turn into:
+```shell
+> ls              # directory -> master (git info)
+```
+
+
+
 ## Contributors
 * [@thbe](https://github.com/thbe)
 * [@erikr](https://github.com/erikr)

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -62,8 +62,13 @@ else
     PROMPT="${prompt}"
 fi
 
+local right_prompt_prefix="%{$fg[white]%}"
+if [ ! -z "$TYPEWRITTEN_RIGHT_PROMPT_PREFIX" ]; then
+    right_prompt_prefix+="$TYPEWRITTEN_RIGHT_PROMPT_PREFIX"
+fi
+
 # right prompt definition
-RPROMPT="${directory_path}"
+RPROMPT="${right_prompt_prefix}${directory_path}"
 RPROMPT+="${git_info}"
 RPROMPT+="${return_code}"
 


### PR DESCRIPTION
Closes #13 

A prefix for the right prompt can be added with the `TYPEWRITTEN_RIGHT_PROMPT_PREFIX` zsh env variable.