### PR TITLE
Append to precmd_functions instead of owerwriting to fix other plugins

### DIFF
--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -113,4 +113,4 @@ _fix_cursor() {
     echo -ne "${cursor}"
 }
 
-precmd_functions=(_fix_cursor _set_right_prompt)
+precmd_functions+=(_fix_cursor _set_right_prompt)

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -113,4 +113,6 @@ _fix_cursor() {
     echo -ne "${cursor}"
 }
 
-precmd_functions+=(_fix_cursor _set_right_prompt)
+autoload -U add-zsh-hook
+add-zsh-hook precmd _fix_cursor
+add-zsh-hook precmd _set_right_prompt


### PR DESCRIPTION
Other plugins like builtin `timer` plugin also use `precmd_functions`, however `typewritten` overwrites it not allowing plugins to display their data.

This PR fixes the problem by appending to `precmd_functions` instead of overwriting.

See https://github.com/ohmyzsh/ohmyzsh/commit/de8d6841b00903f2873a8b009faf7002bfbc1273#diff-8dff0c70d190d2aa1eac09e8613824d4R29

There is also this new way of appending https://github.com/ohmyzsh/ohmyzsh/commit/1ba0af650ac575a7d35b10146d2e7a7b3b2e2ae6#diff-8dff0c70d190d2aa1eac09e8613824d4R30, but I'm not sure if it's active yet (not in my master Oh-My-Zsh yet 🤔, not sure what's the release schedule there). 

Screenshot:

<img width="815" alt="image" src="https://user-images.githubusercontent.com/967132/82431390-6e2ab380-9a43-11ea-873c-8cad674eab62.png">
