### PR TITLE
Changed Foreground Colour to be Default instead of White

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,3 +175,4 @@ When an error happens, the prompt symbol changed to a red color, and the return 
 * [@thbe](https://github.com/thbe)
 * [@erikr](https://github.com/erikr)
 * [@artem-zinnatullin](https://github.com/artem-zinnatullin)
+* [@nizarmah](https://github.com/nizarmah)

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -7,7 +7,7 @@
 #
 
 # git status variables
-ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[white]%}-> %{$fg[magenta]%}"
+ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[default]%}-> %{$fg[magenta]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX=""
 ZSH_THEME_GIT_PROMPT_DIRTY=""
 ZSH_THEME_GIT_PROMPT_CLEAN=""
@@ -15,7 +15,7 @@ ZSH_THEME_GIT_PROMPT_ADDED="%{$fg_bold[cyan]%} +"
 ZSH_THEME_GIT_PROMPT_MODIFIED="%{$fg_bold[yellow]%} !"
 ZSH_THEME_GIT_PROMPT_DELETED="%{$fg_bold[red]%} —"
 ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg_bold[green]%} »"
-ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg_bold[white]%} #"
+ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg_bold[default]%} #"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg_bold[blue]%} ?"
 ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[yellow]%} $"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{$fg_bold[blue]%} •|"
@@ -25,7 +25,7 @@ ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg_bold[blue]%} |•"
 local git_info='$(git_prompt_info)$(git_prompt_status)'
 
 # current user and hostname
-local user_host='%{$fg[yellow]%}%n%{$fg[white]%}@%{$fg[yellow]%}%m '
+local user_host='%{$fg[yellow]%}%n%{$fg[default]%}@%{$fg[yellow]%}%m '
 
 # default: blue, if return code other than 0: red
 local prompt_color="%(?,%{$fg[blue]%},%{$fg[red]%})"
@@ -62,7 +62,7 @@ else
 fi
 
 function _set_right_prompt () {
-    local right_prompt_prefix="%{$fg[white]%}"
+    local right_prompt_prefix="%{$fg[default]%}"
     if [ ! -z "$TYPEWRITTEN_RIGHT_PROMPT_PREFIX" ]; then
         right_prompt_prefix+="$TYPEWRITTEN_RIGHT_PROMPT_PREFIX"
     fi

--- a/typewritten.zsh-theme
+++ b/typewritten.zsh-theme
@@ -111,4 +111,4 @@ autoload -U add-zsh-hook
 add-zsh-hook precmd _fix_cursor
 add-zsh-hook precmd _set_right_prompt
 
-zle_highlight=( default:fg=white )
+zle_highlight=( default:fg=default )


### PR DESCRIPTION
By using the terminal's default foreground colour, the foreground colour would fit both dark and light background colors. This makes the OMZ theme work on both Light and Dark terminal themes.

Let me know if you would like me to make any changes :smiley: I'd love to have this merged with your repository if possible

### Screenshots

![image](https://user-images.githubusercontent.com/5631091/83955820-d78e2d00-a85f-11ea-82d4-a041d9a1c65a.png)
![image](https://user-images.githubusercontent.com/5631091/83955824-ed035700-a85f-11ea-8523-de79098cce6f.png)

