### PR TITLE
Fix issue with right prompt git path with symlinks in super-directory

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,7 +1,7 @@
 typewritten_git_home_display() {
   local git_home=""
   local repo_path="$(git rev-parse --show-toplevel)" > /dev/null 2>&1
-  local current_directory="$(pwd)"
+  local current_directory="$(pwd -P)"
   if [ "$repo_path" != "" -a "$repo_path" != "$current_directory" ]; then
     local repo_name=`basename $repo_path`
     git_home="$repo_name"


### PR DESCRIPTION
This fixes the issue I faced in #35. Instead of evaluating the current path with `pwd`, which shows symlinks by default, we now use `pwd -P` to show physical paths, i.e., avoids symlinks, which is how `git rev-parse --show-toplevel` also works.