### PR TITLE
[feature] add flag for disable return code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,6 @@ To turn it off and display only the current directory, set `TYPEWRITTEN_GIT_RELA
   <img src="media/right_prompt_prefix.png" alt="bash comment prefix" />
 </p>
 
-
 ## More info
 
 ### git status indicators

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Leaves all the room for what's important.
 - Current directory
 - Current git branch
 - [git status indicators](#git-status-indicators)
+- [Return code](#return-code)
 - [Various customization options](#customization-options)
   - [Prompt layout](#typewritten_prompt_layout)
   - [Prompt symbol](#typewritten_symbol)
@@ -192,17 +193,6 @@ To turn it off and display only the current directory, set `TYPEWRITTEN_GIT_RELA
   <img src="media/right_prompt_prefix.png" alt="bash comment prefix" />
 </p>
 
-### `TYPEWRITTEN_DISABLE_RETURN_CODE`
-
-When an error happens, the prompt symbol changed to a red color, and the return code is displayed on the left.
-
-**Default (`TYPEWRITTEN_DISABLE_RETURN_CODE="false"`)**
-
-<p align="center">
-  <img src="media/return_code.png" alt="127 return code" />
-</p>
-
-**Disable (`TYPEWRITTEN_DISABLE_RETURN_CODE="true"`)**
 
 ## More info
 
@@ -225,6 +215,17 @@ Git status can be disabled by setting `git config` value in a repo or globally l
 git config --add oh-my-zsh.hide-status 1
 ```
 
+### return code	
+
+When an error happens, the prompt symbol changes to a red color, and the return code is displayed on the left.	
+
+<p align="center">	
+  <img src="media/return_code.png" alt="127 return code" />	
+</p>
+
+The return code display can be disbled by setting `TYPEWRITTEN_DISABLE_RETURN_CODE` to `true` in your `.zshrc`
+
+
 ## Credits
 
 ### Contributors
@@ -236,7 +237,9 @@ A special thanks to all the contributors to this project
 - [@artem-zinnatullin](https://github.com/artem-zinnatullin)
 - [@nizarmah](https://github.com/nizarmah)
 - [@jletey](https://github.com/jletey)
+- [@pfandzelter](https://github.com/pfandzelter)
+- [@eleven4y](https://github.com/eleven4y)
 
 ### Inspiration
 
-`pure` and `half_pure` layouts are highly inspired by [Pure](https://github.com/sindresorhus/pure)
+`pure` layout is inspired by [Pure](https://github.com/sindresorhus/pure)

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,6 @@ Leaves all the room for what's important.
 - Current directory
 - Current git branch
 - [git status indicators](#git-status-indicators)
-- [Return code](#return-code)
 - [Various customization options](#customization-options)
   - [Prompt layout](#typewritten_prompt_layout)
   - [Prompt symbol](#typewritten_symbol)
@@ -193,6 +192,18 @@ To turn it off and display only the current directory, set `TYPEWRITTEN_GIT_RELA
   <img src="media/right_prompt_prefix.png" alt="bash comment prefix" />
 </p>
 
+### `TYPEWRITTEN_DISABLE_RETURN_CODE`
+
+When an error happens, the prompt symbol changed to a red color, and the return code is displayed on the left.
+
+**Default (`TYPEWRITTEN_DISABLE_RETURN_CODE="false"`)**
+
+<p align="center">
+  <img src="media/return_code.png" alt="127 return code" />
+</p>
+
+**Disable (`TYPEWRITTEN_DISABLE_RETURN_CODE="true"`)**
+
 ## More info
 
 ### git status indicators
@@ -213,14 +224,6 @@ Git status can be disabled by setting `git config` value in a repo or globally l
 ```bash
 git config --add oh-my-zsh.hide-status 1
 ```
-
-### return code
-
-When an error happens, the prompt symbol changed to a red color, and the return code is displayed on the left.
-
-<p align="center">
-  <img src="media/return_code.png" alt="127 return code" />
-</p>
 
 ## Credits
 

--- a/readme.md
+++ b/readme.md
@@ -215,12 +215,12 @@ Git status can be disabled by setting `git config` value in a repo or globally l
 git config --add oh-my-zsh.hide-status 1
 ```
 
-### return code	
+### return code
 
-When an error happens, the prompt symbol changes to a red color, and the return code is displayed on the left.	
+When an error happens, the prompt symbol changes to a red color, and the return code is displayed on the left.
 
-<p align="center">	
-  <img src="media/return_code.png" alt="127 return code" />	
+<p align="center">
+  <img src="media/return_code.png" alt="127 return code" />
 </p>
 
 The return code display can be disbled by setting `TYPEWRITTEN_DISABLE_RETURN_CODE` to `true` in your `.zshrc`

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -28,12 +28,13 @@ _set_left_prompt() {
 	fi
 
   local return_code="%(?,,%F{red}%? )"
-  local typewritten_prompt="$virtualenv$return_code$prompt_color$prompt_symbol %F{default}"
-  local user_host="%F{yellow}%n%F{default}@%F{yellow}%m "
 
   if [ "$TYPEWRITTEN_DISABLE_RETURN_CODE" == true ]; then
     return_code = '';
   fi
+
+  local typewritten_prompt="$virtualenv$return_code$prompt_color$prompt_symbol %F{default}"
+  local user_host="%F{yellow}%n%F{default}@%F{yellow}%m "
 
   if [ "$TYPEWRITTEN_PROMPT_LAYOUT" = "singleline" ]; then
     PROMPT="$typewritten_prompt"

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -28,9 +28,8 @@ _set_left_prompt() {
 	fi
 
   local return_code="%(?,,%F{red}%? )"
-
-  if [ "$TYPEWRITTEN_DISABLE_RETURN_CODE" == true ]; then
-    return_code = '';
+  if [ "$TYPEWRITTEN_DISABLE_RETURN_CODE" = true ]; then
+    return_code=""
   fi
 
   local typewritten_prompt="$virtualenv$return_code$prompt_color$prompt_symbol %F{default}"

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -31,6 +31,10 @@ _set_left_prompt() {
   local typewritten_prompt="$virtualenv$return_code$prompt_color$prompt_symbol %F{default}"
   local user_host="%F{yellow}%n%F{default}@%F{yellow}%m "
 
+  if [ "$TYPEWRITTEN_DISABLE_RETURN_CODE" == true ]; then
+    return_code = '';
+  fi
+
   if [ "$TYPEWRITTEN_PROMPT_LAYOUT" = "singleline" ]; then
     PROMPT="$typewritten_prompt"
   elif [ "$TYPEWRITTEN_PROMPT_LAYOUT" = "singleline_verbose" ]; then


### PR DESCRIPTION
https://github.com/reobin/typewritten/issues/37

Add flag `TYPEWRITTEN_DISABLE_RETURN_CODE` for disable return code

Optimally, add a screenshot to the `readme` file of the project for the case with a disabled `return code`, but I can't create a screenshot in the same style with @reobin 

Ball would be glad to help
