### PR TITLE
feat: Add semantic color mapping options

### DIFF
--- a/lib/colors.zsh
+++ b/lib/colors.zsh
@@ -9,8 +9,8 @@ declare -A color_mappings=(
   ["info_positive"]="green"
   ["info_negative"]="red"
 
-  ["info_neutral_2"]="blue"
   ["info_neutral_1"]="yellow"
+  ["info_neutral_2"]="blue"
 
   ["info_special"]="cyan"
 )

--- a/lib/colors.zsh
+++ b/lib/colors.zsh
@@ -24,17 +24,47 @@ declare -A colors=(
   ["git_status_stash"]="yellow"
 )
 
+declare -A color_mappings=(
+  ["default"]="default"
+  ["white"]="white"
+  ["black"]="black"
+  ["magenta"]="magenta"
+  ["blue"]="blue"
+  ["red"]="red"
+  ["yellow"]="yellow"
+  ["green"]="green"
+  ["cyan"]="cyan"
+)
+
 _setup_custom_colors() {
+  if [[ $TYPEWRITTEN_COLOR_MAPPINGS =~ ^[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+(\;[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+)*$ ]]; then
+    values=($(echo $TYPEWRITTEN_COLOR_MAPPINGS | tr ";" "\n"))
+    for value in $values; do
+      value_definition=($(echo $value | tr ":" "\n"))
+      color_mappings[$value_definition[1]]=$value_definition[2]
+    done
+  elif [[ ! -z $TYPEWRITTEN_COLOR_MAPPINGS ]]; then
+    echo "$TYPEWRITTEN_COLOR_MAPPINGS is not formatted correctly.
+Format it like so: \"value:#009090;value:red\", etc."
+  fi
+
   if [[ $TYPEWRITTEN_COLORS =~ ^[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+(\;[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+)*$ ]]; then
-    custom_colors=($(echo $TYPEWRITTEN_COLORS | tr ";" "\n"))
-    for value in "${custom_colors[@]}"; do
-      color_definition=($(echo $value | tr ":" "\n"))
-      colors[$color_definition[1]]="$color_definition[2]"
+    values=($(echo $TYPEWRITTEN_COLORS | tr ";" "\n"))
+    for value in $values; do
+      value_definition=($(echo $value | tr ":" "\n"))
+      colors[$value_definition[1]]=$value_definition[2]
     done
   elif [[ ! -z $TYPEWRITTEN_COLORS ]]; then
-    echo "TYPEWRITTEN_COLORS is not formatted correctly.
-Format it like so: \"prompt:red;symbol:#008080;user:345\", etc."
+    echo "$TYPEWRITTEN_COLORS is not formatted correctly.
+Format it like so: \"value:#009090;value:red\", etc."
   fi
+
+  # apply mapped colors
+  for key value in ${(kv)colors}; do
+    if [ ! -z $color_mappings[$value] ]; then
+      colors[$key]=$color_mappings[$value]
+    fi
+  done
 }
 
 _setup_custom_colors

--- a/lib/colors.zsh
+++ b/lib/colors.zsh
@@ -1,70 +1,72 @@
-declare -A colors=(
-  ["symbol"]="blue"
-  ["symbol_error"]="red"
-  ["error_code"]="red"
-  ["current_directory"]="magenta"
-  ["right_prompt_prefix"]="default"
-  ["host"]="yellow"
-  ["host_user_connector"]="default"
-  ["user"]="yellow"
-  ["prompt"]="default"
-  ["virtualenv"]="default"
-  ["git_branch"]="magenta"
-  ["arrow"]="default"
-  ["git_rebasing"]="magenta"
-  ["git_status_staged"]="green"
-  ["git_status_new"]="blue"
-  ["git_status_modified"]="yellow"
-  ["git_status_renamed"]="cyan"
-  ["git_status_deleted"]="red"
-  ["git_status_unmerged"]="default"
-  ["git_status_diverged"]="blue"
-  ["git_status_ahead"]="blue"
-  ["git_status_behind"]="blue"
-  ["git_status_stash"]="yellow"
-)
-
 declare -A color_mappings=(
-  ["default"]="default"
-  ["white"]="white"
-  ["black"]="black"
-  ["magenta"]="magenta"
-  ["blue"]="blue"
-  ["red"]="red"
-  ["yellow"]="yellow"
-  ["green"]="green"
-  ["cyan"]="cyan"
+  ["foreground"]="default"
+
+  ["primary"]="magenta"
+  ["secondary"]="blue"
+
+  ["accent"]="default"
+
+  ["info_positive"]="green"
+  ["info_negative"]="red"
+
+  ["info_neutral_2"]="blue"
+  ["info_neutral_1"]="yellow"
+
+  ["info_special"]="cyan"
 )
 
-_setup_custom_colors() {
-  if [[ $TYPEWRITTEN_COLOR_MAPPINGS =~ ^[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+(\;[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+)*$ ]]; then
-    values=($(echo $TYPEWRITTEN_COLOR_MAPPINGS | tr ";" "\n"))
-    for value in $values; do
-      value_definition=($(echo $value | tr ":" "\n"))
-      color_mappings[$value_definition[1]]=$value_definition[2]
-    done
-  elif [[ ! -z $TYPEWRITTEN_COLOR_MAPPINGS ]]; then
-    echo "$TYPEWRITTEN_COLOR_MAPPINGS is not formatted correctly.
-Format it like so: \"value:#009090;value:red\", etc."
-  fi
-
-  if [[ $TYPEWRITTEN_COLORS =~ ^[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+(\;[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+)*$ ]]; then
-    values=($(echo $TYPEWRITTEN_COLORS | tr ";" "\n"))
-    for value in $values; do
-      value_definition=($(echo $value | tr ":" "\n"))
-      colors[$value_definition[1]]=$value_definition[2]
-    done
-  elif [[ ! -z $TYPEWRITTEN_COLORS ]]; then
-    echo "$TYPEWRITTEN_COLORS is not formatted correctly.
-Format it like so: \"value:#009090;value:red\", etc."
-  fi
-
-  # apply mapped colors
-  for key value in ${(kv)colors}; do
-    if [ ! -z $color_mappings[$value] ]; then
-      colors[$key]=$color_mappings[$value]
-    fi
+if [[ $TYPEWRITTEN_COLOR_MAPPINGS =~ ^[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+(\;[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+)*$ ]]; then
+  values=($(echo $TYPEWRITTEN_COLOR_MAPPINGS | tr ";" "\n"))
+  for value in $values; do
+    value_definition=($(echo $value | tr ":" "\n"))
+    color_mappings[$value_definition[1]]=$value_definition[2]
   done
-}
+elif [[ ! -z $TYPEWRITTEN_COLOR_MAPPINGS ]]; then
+  echo "$TYPEWRITTEN_COLOR_MAPPINGS is not formatted correctly.
+Format it like so: \"value:#009090;value:red\", etc."
+fi
 
-_setup_custom_colors
+declare -A colors=(
+  ["prompt"]=$color_mappings[foreground]
+
+  ["current_directory"]=$color_mappings[primary]
+  ["git_branch"]=$color_mappings[primary]
+
+  ["symbol"]=$color_mappings[secondary]
+  ["git_status_new"]=$color_mappings[secondary]
+
+  ["arrow"]=$color_mappings[accent]
+  ["host_user_connector"]=$color_mappings[accent]
+  ["right_prompt_prefix"]=$color_mappings[accent]
+
+  ["symbol_error"]=$color_mappings[info_negative]
+  ["error_code"]=$color_mappings[info_negative]
+  ["git_status_deleted"]=$color_mappings[info_negative]
+
+  ["git_status_staged"]=$color_mappings[info_positive]
+
+  ["host"]=$color_mappings[info_neutral_1]
+  ["user"]=$color_mappings[info_neutral_1]
+  ["virtualenv"]=$color_mappings[info_neutral_1]
+  ["git_status_stash"]=$color_mappings[info_neutral_1]
+  ["git_status_modified"]=$color_mappings[info_neutral_1]
+
+  ["git_status_diverged"]=$color_mappings[info_neutral_2]
+  ["git_status_ahead"]=$color_mappings[info_neutral_2]
+  ["git_status_behind"]=$color_mappings[info_neutral_2]
+  ["git_rebasing"]=$color_mappings[info_neutral_2]
+
+  ["git_status_renamed"]=$color_mappings[info_special]
+  ["git_status_unmerged"]=$color_mappings[info_special]
+)
+
+if [[ $TYPEWRITTEN_COLORS =~ ^[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+(\;[#_0-9a-zA-Z]+:[#_0-9a-zA-Z]+)*$ ]]; then
+  values=($(echo $TYPEWRITTEN_COLORS | tr ";" "\n"))
+  for value in $values; do
+    value_definition=($(echo $value | tr ":" "\n"))
+    colors[$value_definition[1]]=$value_definition[2]
+  done
+elif [[ ! -z $TYPEWRITTEN_COLORS ]]; then
+  echo "$TYPEWRITTEN_COLORS is not formatted correctly.
+Format it like so: \"value:#009090;value:red\", etc."
+fi

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -52,7 +52,7 @@ _redraw() {
   _env_prompt="$_virtualenv$_prompt"
 
   _layout="$TYPEWRITTEN_PROMPT_LAYOUT"
-  _git_info="$prompt_data[_git_branch]$prompt_data[_git_status]"
+  _git_info="%F{$_git_branch_color}$prompt_data[_git_branch]$prompt_data[_git_status]"
   if [ "$_layout" = "half_pure" ]; then
     PROMPT="$BREAK_LINE$_git_info$BREAK_LINE$_env_prompt"
     RPROMPT="$_right_prompt_prefix%F{$_current_directory_color}$prompt_data[_git_home]$_current_directory"

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -52,9 +52,9 @@ _redraw() {
   _env_prompt="$_virtualenv$_prompt"
 
   _layout="$TYPEWRITTEN_PROMPT_LAYOUT"
-  _git_info="%F{$_git_branch_color}$prompt_data[_git_branch]$prompt_data[_git_status]"
+  _git_info="$prompt_data[_git_branch]$prompt_data[_git_status]"
   if [ "$_layout" = "half_pure" ]; then
-    PROMPT="$BREAK_LINE$_git_info$BREAK_LINE$_env_prompt"
+    PROMPT="$BREAK_LINE%F{$_git_branch_color}$_git_info$BREAK_LINE$_env_prompt"
     RPROMPT="$_right_prompt_prefix%F{$_current_directory_color}$prompt_data[_git_home]$_current_directory"
   else
     local _git_arrow_info=""


### PR DESCRIPTION
`TYPEWRITTEN_COLOR_MAPPINGS` option was added.

Possible mappings and their default values:
```bash
  ["foreground"]="default"

  ["primary"]="magenta"
  ["secondary"]="blue"

  ["accent"]="default"

  ["info_positive"]="green"
  ["info_negative"]="red"

  ["info_neutral_2"]="blue"
  ["info_neutral_1"]="yellow"

  ["info_special"]="cyan"
```

They can be defined just like standard sections colors:
```bash
export TYPEWRITTEN_COLOR_MAPPINGS="primary:#9580FF;secondary:#8AFF80;accent:#FFFF80;info_negative:#FF80BF;info_positive:#8AFF80;info_neutral_1:#FF9580;info_neutral_2:#FFFF80;info_special:#80FFEA"
```

Above is an example of a dracula theme.