### PR TITLE
Add oh-my-zsh note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ autoload -U promptinit; promptinit
 prompt typewritten
 ```
 
+Note: if using `oh-my-zsh`, set `ZSH_THEME=""` in your `.zshrc` to disable oh-my-zsh themes.
+
 ### Other ways to install
 
 Many other ways to install typewritten are available in the [docs](https://typewritten.dev/#/installation)


### PR DESCRIPTION
This line appears in the "Manual" section of the [installation docs](https://typewritten.dev/#/installation?id=manual) but not in the readme. 

I know it may have been omitted to funnel users to other ways to install. But not having it in the readme led to some confusion when I was trying to get the theme working by just using the instructions I saw in the readme.