### PR TITLE
feat: Support git relative path on pure layout

### DIFF
--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -102,7 +102,7 @@ tw_redraw() {
       tw_git_arrow_info=" $tw_arrow %F{$tw_git_branch_color}$tw_git_info"
     fi;
     if [ "$tw_layout" = "pure" ]; then
-      PROMPT="$BREAK_LINE$tw_home_relative_wd$tw_git_arrow_info$BREAK_LINE$tw_env_prompt"
+      PROMPT="$BREAK_LINE$tw_git_relative_wd$tw_git_arrow_info$BREAK_LINE$tw_env_prompt"
       RPROMPT=""
     else
       if [ "$tw_layout" = "singleline_verbose" ]; then

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -72,6 +72,10 @@ tw_get_git_relative_wd() {
 
   local tw_git_relative_wd="%F{$tw_current_directory_color}$tw_git_home%c"
 
+  if [[ "$TYPEWRITTEN_RELATIVE_PATH" = "" &&  "$TYPEWRITTEN_PROMPT_LAYOUT" = "pure" ]]; then
+      tw_git_relative_wd=$tw_home_relative_wd
+    fi;
+
   if [[ "$TYPEWRITTEN_RELATIVE_PATH" = "home" ]]; then
     tw_git_relative_wd=$tw_home_relative_wd
   fi;

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -65,33 +65,34 @@ tw_get_home_relative_wd() {
   echo "%F{$tw_current_directory_color}%~"
 }
 
-tw_get_git_relative_wd() {
+tw_get_displayed_wd() {
   local tw_home_relative_wd="$1"
   local tw_git_branch="$2"
   local tw_git_home="$3"
 
-  local tw_git_relative_wd="%F{$tw_current_directory_color}$tw_git_home%c"
+  local tw_displayed_wd="%F{$tw_current_directory_color}$tw_git_home%c"
 
-  if [[ "$TYPEWRITTEN_RELATIVE_PATH" = "" &&  "$TYPEWRITTEN_PROMPT_LAYOUT" = "pure" ]]; then
-      tw_git_relative_wd=$tw_home_relative_wd
-    fi;
+# The pure layout defaults to home relative working directory, but allows customization
+  if [[  "$TYPEWRITTEN_PROMPT_LAYOUT" = "pure" && "$TYPEWRITTEN_RELATIVE_PATH" = "" ]]; then
+    tw_displayed_wd=$tw_home_relative_wd
+  fi;
 
   if [[ "$TYPEWRITTEN_RELATIVE_PATH" = "home" ]]; then
-    tw_git_relative_wd=$tw_home_relative_wd
+    tw_displayed_wd=$tw_home_relative_wd
   fi;
 
   if [[ "$TYPEWRITTEN_RELATIVE_PATH" = "adaptive" ]]; then
     if [[ "$tw_git_branch" = "" ]]; then
-      tw_git_relative_wd=$tw_home_relative_wd
+      tw_displayed_wd=$tw_home_relative_wd
     fi;
   fi;
 
-  echo $tw_git_relative_wd
+  echo $tw_displayed_wd
 }
 
 tw_redraw() {
   tw_home_relative_wd="$(tw_get_home_relative_wd)"
-  tw_git_relative_wd="$(tw_get_git_relative_wd $tw_home_relative_wd $tw_prompt_data[tw_git_branch] $tw_prompt_data[tw_git_home])"
+  tw_displayed_wd="$(tw_get_displayed_wd $tw_home_relative_wd $tw_prompt_data[tw_git_branch] $tw_prompt_data[tw_git_home])"
 
   tw_env_prompt="$(tw_get_virtual_env)$tw_prompt"
 
@@ -99,14 +100,14 @@ tw_redraw() {
   tw_git_info="$tw_prompt_data[tw_git_branch]$tw_prompt_data[tw_git_status]"
   if [ "$tw_layout" = "half_pure" ]; then
     PROMPT="$BREAK_LINE%F{$tw_git_branch_color}$tw_git_info$BREAK_LINE$tw_env_prompt"
-    RPROMPT="$tw_right_prompt_prefix$tw_git_relative_wd"
+    RPROMPT="$tw_right_prompt_prefix$tw_displayed_wd"
   else
     local tw_git_arrow_info=""
     if [ "$tw_git_info" != "" ]; then
       tw_git_arrow_info=" $tw_arrow %F{$tw_git_branch_color}$tw_git_info"
     fi;
     if [ "$tw_layout" = "pure" ]; then
-      PROMPT="$BREAK_LINE$tw_git_relative_wd$tw_git_arrow_info$BREAK_LINE$tw_env_prompt"
+      PROMPT="$BREAK_LINE$tw_displayed_wd$tw_git_arrow_info$BREAK_LINE$tw_env_prompt"
       RPROMPT=""
     else
       if [ "$tw_layout" = "singleline_verbose" ]; then
@@ -116,7 +117,7 @@ tw_redraw() {
       else
         PROMPT="$tw_env_prompt"
       fi;
-      RPROMPT="$tw_right_prompt_prefix$tw_git_relative_wd$tw_git_arrow_info"
+      RPROMPT="$tw_right_prompt_prefix$tw_displayed_wd$tw_git_arrow_info"
     fi;
   fi;
 

--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -61,19 +61,17 @@ tw_get_virtual_env() {
   fi;
 }
 
-tw_get_home_relative_wd() {
-  echo "%F{$tw_current_directory_color}%~"
-}
-
 tw_get_displayed_wd() {
-  local tw_home_relative_wd="$1"
-  local tw_git_branch="$2"
-  local tw_git_home="$3"
+  local tw_git_branch=$tw_prompt_data[tw_git_branch]
+  local tw_git_home=$tw_prompt_data[tw_git_home]
 
-  local tw_displayed_wd="%F{$tw_current_directory_color}$tw_git_home%c"
+  local tw_home_relative_wd="%~"
+  local tw_git_relative_wd="$tw_git_home%c"
 
-# The pure layout defaults to home relative working directory, but allows customization
-  if [[  "$TYPEWRITTEN_PROMPT_LAYOUT" = "pure" && "$TYPEWRITTEN_RELATIVE_PATH" = "" ]]; then
+  local tw_displayed_wd="$tw_git_relative_wd"
+
+  # The pure layout defaults to home relative working directory, but allows customization
+  if [[ "$TYPEWRITTEN_PROMPT_LAYOUT" = "pure" && "$TYPEWRITTEN_RELATIVE_PATH" = "" ]]; then
     tw_displayed_wd=$tw_home_relative_wd
   fi;
 
@@ -87,12 +85,11 @@ tw_get_displayed_wd() {
     fi;
   fi;
 
-  echo $tw_displayed_wd
+  echo "%F{$tw_current_directory_color}$tw_displayed_wd"
 }
 
 tw_redraw() {
-  tw_home_relative_wd="$(tw_get_home_relative_wd)"
-  tw_displayed_wd="$(tw_get_displayed_wd $tw_home_relative_wd $tw_prompt_data[tw_git_branch] $tw_prompt_data[tw_git_home])"
+  tw_displayed_wd="$(tw_get_displayed_wd)"
 
   tw_env_prompt="$(tw_get_virtual_env)$tw_prompt"
 


### PR DESCRIPTION
closes #107 

Updates `pure` layout to allow for customization of the `TYPEWRITTEN_RELATIVE_PATH`.

This layout uses the `TYPEWRITTEN_RELATIVE_PATH="home"` by default so a check has been added in `tw_get_displayed_wd()`.  
 - When `TYPEWRITTEN_RELATIVE_PATH` is not set and the user has selected `TYPEWRITTEN_PROMPT_LAYOUT="pure"` we default to "home". 
 -  If the user does have customization for the path set we will use that.    

Cleanup around `tw_get_displayed_wd()` based on changes is also included.

<details>
<summary>Before</summary>

<img width="1677" alt="Screen Shot 2021-02-21 at 12 20 35 PM" src="https://user-images.githubusercontent.com/21298255/108632933-63240a00-743f-11eb-8579-2f7225ad79db.png">

</details>

<details>
<summary>After</summary>

<img width="1670" alt="Screen Shot 2021-02-21 at 12 21 37 PM" src="https://user-images.githubusercontent.com/21298255/108632942-6f0fcc00-743f-11eb-9074-071620b95731.png">

</details>