### PR TITLE
fix(installScript): Improved install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 [![Forkers repo roster for @reobin/typewritten](https://reporoster.com/forks/reobin/typewritten)](https://github.com/reobin/typewritten/network/members)
 
-## Inspiration
+## Credits
 
-`pure` layout is inspired by [Pure](https://github.com/sindresorhus/pure)
+- `pure` layout is inspired by [Pure](https://github.com/sindresorhus/pure)
+- `npm` install and uninstall scripts are from [Spaceship prompt](https://github.com/spaceship-prompt/spaceship-prompt)
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,45 +1,137 @@
-SOURCE="$PWD"
-DEST="/usr/local/share/zsh/site-functions"
+#!/usr/bin/env zsh
+#
+# This script is a clone/fork of the spaceship-prompt install script and it was
+# changed in order to install the Typewritten prompt instead.
+#
+# Original author: Denys Dovhan, denysdovhan.com
+# From: https://github.com/spaceship-prompt/spaceship-prompt
 
-SOURCE_TYPEWRITTEN="$SOURCE/typewritten.zsh"
-DEST_TYPEWRITTEN="$DEST/prompt_typewritten_setup"
+# ------------------------------------------------------------------------------
+# Colors
+# Set color variables for colorful output
+# ------------------------------------------------------------------------------
 
-SOURCE_ASYNC="$SOURCE/async.zsh"
-DEST_ASYNC="$DEST/async"
-
-ZSHRC="$HOME/.zshrc"
-
-echo "Installing typewritten...\n"
-
-mkdir -p "$DEST"
-
-link() {
-  local source="$1"
-  local dest="$2"
-  if [ -f "$dest" ]; then
-    echo "Unlinking $dest"
-    rm "$dest"
-  fi
-  echo "Linking $source -> $dest\n"
-  ln -sf "$source" "$dest"
-}
-
-link "$SOURCE_TYPEWRITTEN" "$DEST_TYPEWRITTEN"
-link "$SOURCE_ASYNC" "$DEST_ASYNC"
-
-echo "Setting up zsh prompt..."
-if sed "s/#.*//" "$ZSHRC" | grep -q "prompt typewritten"; then
-  echo "typewritten is already present in .zshrc!\n"
-  echo "Reload zsh."
-  exit
+# If we have tput, let's set colors
+if [[ ! -z $(which tput 2> /dev/null) ]]; then
+  reset=$(tput sgr0)
+  bold=$(tput bold)
+  red=$(tput setaf 1)
+  green=$(tput setaf 2)
+  yellow=$(tput setaf 3)
+  blue=$(tput setaf 4)
+  magenta=$(tput setaf 5)
+  cyan=$(tput setaf 6)
 fi
 
-config="\n# Set typewritten ZSH as a prompt"
-config+="\nautoload -U promptinit; promptinit"
-config+="\nprompt typewritten"
-echo "$config" >> "$ZSHRC"
+# ------------------------------------------------------------------------------
+# VARIABLES
+# Paths to important resources
+# ------------------------------------------------------------------------------
 
-echo "Done.\n"
-echo "Reload zsh.\n"
+ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
+REPO='https://github.com/reobin/typewritten.git'
 
-exit
+SOURCE="$PWD/typewritten.zsh"
+ASYNC_SOURCE="$PWD/async.zsh"
+USER_SOURCE="${ZDOTDIR:-$HOME}/.typewritten-prompt"
+
+DEST='/usr/local/share/zsh/site-functions'
+USER_DEST="${ZDOTDIR:-$HOME}/.zfunctions"
+
+# ------------------------------------------------------------------------------
+# HELPERS
+# Useful functions for common tasks
+# ------------------------------------------------------------------------------
+
+# Paint text in specific color with reset
+# USAGE:
+#   paint <color> [text...]
+paint() {
+  local color=$1 rest=${@:2}
+  echo "$color$rest$reset"
+}
+
+# Aliases for common used colors
+# Colon at the end is required: https://askubuntu.com/a/521942
+# USAGE:
+#   info|warn|error|success|code [...text]
+info()    { paint "$cyan"   "TYPEWRITTEN: $@" ; }
+warn()    { paint "$yellow" "TYPEWRITTEN: $@" ; }
+error()   { paint "$red"    "TYPEWRITTEN: $@" ; }
+success() { paint "$green"  "TYPEWRITTEN: $@" ; }
+code()    { paint "$bold"   "TYPEWRITTEN: $@" ; }
+
+# Append text in .zshrc
+# USAGE:
+#   append_zshrc [text...]
+append_zshrc() {
+  info "These lines will be added to your \"${ZDOTDIR:-$HOME}/.zshrc\" file:"
+  code "$@"
+  echo "$@" >> "${ZDOTDIR:-$HOME}/.zshrc"
+}
+
+# ------------------------------------------------------------------------------
+# MAIN
+# Checkings and installing process
+# ------------------------------------------------------------------------------
+
+main() {
+  # How we install Typewritten:
+  #   1. Install via NPM
+  #   2. Install via curl or wget
+  if [[ ! -f "$SOURCE" ]]; then
+    warn "Typewritten is not present in current directory"
+    # Clone repo into the ${ZDOTDIR:-$HOME}/.typewritten-prompt and change SOURCE
+    git clone "$REPO" "$USER_SOURCE"
+    SOURCE="$USER_SOURCE/typewritten.zsh"
+    ASYNC_SOURCE="$USER_SOURCE/async.zsh"
+  else
+    info "Typewritten is present in current directory"
+  fi
+
+  # If we can't symlink to the site-functions, then try to use .zfunctions instead
+  if [[ ! -w "$DEST" ]]; then
+    error "Failed to symlink $SOURCE to $DEST."
+    error "Failed to symlink $ASYNC_SOURCE to $DEST."
+
+    # Use $USER_DEST instead
+    DEST="$USER_DEST"
+
+    info "Adding $DEST to fpath..."
+    echo 'fpath=($fpath "'"$DEST"'")' >> "$ZSHRC"
+
+    info "Trying to symlink $SOURCE to $DEST"
+    info "Trying to symlink $ASYNC_SOURCE to $DEST"
+  fi
+
+  # Link prompt entry point to fpath
+  info "Linking $SOURCE to $DEST/prompt_typewritten_setup..."
+  info "Linking $ASYNC_SOURCE to $DEST/async_typewritten..."
+  mkdir -p "$DEST"
+  ln -sf "$SOURCE" "$DEST/prompt_typewritten_setup"
+  ln -sf "$ASYNC_SOURCE" "$DEST/async_typewritten"
+
+  # If 'prompt typewritten' is already present in .zshrc, then skip
+  if sed 's/#.*//' "$ZSHRC" | grep -q "prompt typewritten"; then
+    warn "Typewritten is already present in .zshrc!"
+    exit
+  fi
+
+  # Enabling statements for .zshrc
+  msg="\n# Set Typewritten ZSH as a prompt"
+  msg+="\nautoload -U promptinit; promptinit"
+  msg+="\nprompt spaceship"
+
+  # Check if appending was successful and perform corresponding actions
+  if append_zshrc "$msg"; then
+    success "Done! Please, reload your terminal."
+    echo
+  else
+    error "Cannot automatically insert prompt init commands."
+    error "Please insert these line into your \"${ZDOTDIR:-$HOME}/.zshrc\" file:"
+    code "$msg"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 #
 # This script is a clone/fork of the spaceship-prompt install script and it was
-# changed in order to install the Typewritten prompt instead.
+# changed in order to install the typewritten prompt instead.
 #
 # Original author: Denys Dovhan, denysdovhan.com
 # From: https://github.com/spaceship-prompt/spaceship-prompt
@@ -55,11 +55,11 @@ paint() {
 # Colon at the end is required: https://askubuntu.com/a/521942
 # USAGE:
 #   info|warn|error|success|code [...text]
-info()    { paint "$cyan"   "TYPEWRITTEN: $@" ; }
-warn()    { paint "$yellow" "TYPEWRITTEN: $@" ; }
-error()   { paint "$red"    "TYPEWRITTEN: $@" ; }
-success() { paint "$green"  "TYPEWRITTEN: $@" ; }
-code()    { paint "$bold"   "TYPEWRITTEN: $@" ; }
+info()    { paint "$cyan"   "typewritten: $@" ; }
+warn()    { paint "$yellow" "typewritten: $@" ; }
+error()   { paint "$red"    "typewritten: $@" ; }
+success() { paint "$green"  "typewritten: $@" ; }
+code()    { paint "$bold"   "typewritten: $@" ; }
 
 # Append text in .zshrc
 # USAGE:
@@ -76,17 +76,17 @@ append_zshrc() {
 # ------------------------------------------------------------------------------
 
 main() {
-  # How we install Typewritten:
+  # How we install typewritten:
   #   1. Install via NPM
   #   2. Install via curl or wget
   if [[ ! -f "$SOURCE" ]]; then
-    warn "Typewritten is not present in current directory"
+    warn "typewritten is not present in current directory"
     # Clone repo into the ${ZDOTDIR:-$HOME}/.typewritten-prompt and change SOURCE
     git clone "$REPO" "$USER_SOURCE"
     SOURCE="$USER_SOURCE/typewritten.zsh"
     ASYNC_SOURCE="$USER_SOURCE/async.zsh"
   else
-    info "Typewritten is present in current directory"
+    info "typewritten is present in current directory"
   fi
 
   # If we can't symlink to the site-functions, then try to use .zfunctions instead
@@ -113,14 +113,14 @@ main() {
 
   # If 'prompt typewritten' is already present in .zshrc, then skip
   if sed 's/#.*//' "$ZSHRC" | grep -q "prompt typewritten"; then
-    warn "Typewritten is already present in .zshrc!"
+    warn "typewritten is already present in .zshrc!"
     exit
   fi
 
   # Enabling statements for .zshrc
-  msg="\n# Set Typewritten ZSH as a prompt"
+  msg="\n# Set typewritten ZSH as a prompt"
   msg+="\nautoload -U promptinit; promptinit"
-  msg+="\nprompt spaceship"
+  msg+="\nprompt typewritten"
 
   # Check if appending was successful and perform corresponding actions
   if append_zshrc "$msg"; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,10 +106,10 @@ main() {
 
   # Link prompt entry point to fpath
   info "Linking $SOURCE to $DEST/prompt_typewritten_setup..."
-  info "Linking $ASYNC_SOURCE to $DEST/async_typewritten..."
+  info "Linking $ASYNC_SOURCE to $DEST/async..."
   mkdir -p "$DEST"
   ln -sf "$SOURCE" "$DEST/prompt_typewritten_setup"
-  ln -sf "$ASYNC_SOURCE" "$DEST/async_typewritten"
+  ln -sf "$ASYNC_SOURCE" "$DEST/async"
 
   # If 'prompt typewritten' is already present in .zshrc, then skip
   if sed 's/#.*//' "$ZSHRC" | grep -q "prompt typewritten"; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env zsh
 #
-# Author: Denys Dovhan, denysdovhan.com
-# https://github.com/spaceship-prompt/spaceship-prompt
+# This script is a clone/fork of the spaceship-prompt uninstall script and it was
+# changed in order to install the typewritten prompt instead.
+#
+# Original author: Denys Dovhan, denysdovhan.com
+# From: https://github.com/spaceship-prompt/spaceship-prompt
 
 # ------------------------------------------------------------------------------
 # Colors
@@ -54,11 +57,11 @@ paint() {
 # Colon at the end is required: https://askubuntu.com/a/521942
 # USAGE:
 #   info|warn|error|success|code [...text]
-info()    { paint "$cyan"   "Typewritten: $@" ; }
-warn()    { paint "$yellow" "Typewritten: $@" ; }
-error()   { paint "$red"    "Typewritten: $@" ; }
-success() { paint "$green"  "Typewritten: $@" ; }
-code()    { paint "$bold"   "Typewritten: $@" ; }
+info()    { paint "$cyan"   "typewritten: $@" ; }
+warn()    { paint "$yellow" "typewritten: $@" ; }
+error()   { paint "$red"    "typewritten: $@" ; }
+success() { paint "$green"  "typewritten: $@" ; }
+code()    { paint "$bold"   "typewritten: $@" ; }
 
 # Check if symlink is exists and remove it
 # USAGE:
@@ -76,25 +79,48 @@ rmln() {
 # Checkings and uninstalling process
 # ------------------------------------------------------------------------------
 
+remove_zshrc_content() {
+  info "Removing typewritten from \"${ZDOTDIR:-$HOME}/.zshrc\""
+  # Remove enabling statements from .zshrc
+  # and remove typewritten configuration
+  sed '/^# Set typewritten ZSH as a prompt$/d' "$ZSHRC" | \
+  sed '/^autoload -U promptinit; promptinit$/d' | \
+  sed '/^prompt typewritten$/d' | \
+  sed '/.*TYPEWRITTEN_.*=.*$/d' > "$ZSHRC.bak" && \
+  mv -- "$ZSHRC.bak" "$ZSHRC"
+}
+
 main() {
   # Remove prompt setup symlink
   if [[ -L "$GLOBAL_DEST_SETUP" || -L "$USER_DEST_SETUP" ]]; then
     rmln "$GLOBAL_DEST_SETUP"
     rmln "$USER_DEST_SETUP"
   else
-    warn "Symlinks to Typewritten setup are not found."
+    warn "Symlinks to typewritten setup are not found."
   fi
 
   # Remove prompt async symlink
   if [[ -L "$GLOBAL_DEST_ASYNC" || -L "$USER_DEST_ASYNC" ]]; then
-    rmln "$GLOBAL_DEST_ASYNC"
-    rmln "$USER_DEST_ASYNC"
+    rmln "$GLOBAL_DEST_ASYNC" rmln "$USER_DEST_ASYNC"
   else
-    warn "Symlinks to Typewritten async are not found."
+    warn "Symlinks to typewritten async are not found."
   fi
 
-  success "Done! Typewritten installation has been removed!"
-  info "Don't forget to remove Typewritten config lines in ~/.zshrc"
+  # Remove typewritten from .zshrc
+  if grep -q "typewritten" "$ZSHRC"; then
+    if [[ '-y' == $1 ]]; then
+      remove_zshrc_content
+    else
+      read "answer?Would you like to remove you typewritten ZSH configuration from .zshrc? (y/N)"
+      if [[ 'y' == ${answer:l} ]]; then
+        remove_zshrc_content
+      fi
+    fi
+  else
+    warn "typewritten configuration not found in \"${ZDOTDIR:-$HOME}/.zshrc\"!"
+  fi
+
+  success "Done! typewritten installation has been removed!"
   success "Please, reload your terminal."
 }
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -114,7 +114,10 @@ main() {
     else
       read "answer?Would you like to remove you typewritten ZSH configuration from .zshrc? (y/N)"
       if [[ 'y' == ${answer:l} ]]; then
-        remove_zshrc_content
+        read "answer?Are you sure? Any symlinks to your ZSH configuration file might be removed? (y/N)"
+        if [[ 'y' == ${answer:l} ]]; then
+          remove_zshrc_content
+        fi
       fi
     fi
   else

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
-#
+
 # This script is a clone/fork of the spaceship-prompt uninstall script and it was
 # changed in order to install the typewritten prompt instead.
 #
@@ -101,7 +101,8 @@ main() {
 
   # Remove prompt async symlink
   if [[ -L "$GLOBAL_DEST_ASYNC" || -L "$USER_DEST_ASYNC" ]]; then
-    rmln "$GLOBAL_DEST_ASYNC" rmln "$USER_DEST_ASYNC"
+    rmln "$GLOBAL_DEST_ASYNC"
+    rmln "$USER_DEST_ASYNC"
   else
     warn "Symlinks to typewritten async are not found."
   fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,10 +1,101 @@
-DEST="/usr/local/share/zsh/site-functions"
-DEST_TYPEWRITTEN="$DEST/prompt_typewritten_setup"
-DEST_ASYNC="$DEST/async"
+#!/usr/bin/env zsh
+#
+# Author: Denys Dovhan, denysdovhan.com
+# https://github.com/spaceship-prompt/spaceship-prompt
 
-echo "Unlinking zsh prompt files...\n"
-unlink "$DEST_TYPEWRITTEN"
-unlink "$DEST_ASYNC"
+# ------------------------------------------------------------------------------
+# Colors
+# Set color variables for colorful output
+# ------------------------------------------------------------------------------
 
-echo "Done.\n"
-echo "Don't forget to remove typewritten config lines in ~/.zshrc"
+# If we have tput, let's set colors
+if [[ ! -z $(which tput 2> /dev/null) ]]; then
+  reset=$(tput sgr0)
+  bold=$(tput bold)
+  red=$(tput setaf 1)
+  green=$(tput setaf 2)
+  yellow=$(tput setaf 3)
+  blue=$(tput setaf 4)
+  magenta=$(tput setaf 5)
+  cyan=$(tput setaf 6)
+fi
+
+# ------------------------------------------------------------------------------
+# VARIABLES
+# Paths to important resources
+# ------------------------------------------------------------------------------
+
+ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
+USER_SOURCE="${ZDOTDIR:-$HOME}/.typewritten-prompt"
+
+PROMPT_SETUP="prompt_typewritten_setup"
+PROMPT_ASYNC="async"
+
+GLOBAL_DEST_SETUP="/usr/local/share/zsh/site-functions/$PROMPT_SETUP"
+USER_DEST_SETUP="${ZDOTDIR:-$HOME}/.zfunctions/$PROMPT_SETUP"
+
+GLOBAL_DEST_ASYNC="/usr/local/share/zsh/site-functions/$PROMPT_ASYNC"
+USER_DEST_ASYNC="${ZDOTDIR:-$HOME}/.zfunctions/$PROMPT_ASYNC"
+
+# ------------------------------------------------------------------------------
+# HELPERS
+# Useful functions for common tasks
+# ------------------------------------------------------------------------------
+
+# Paint text in specific color with reset
+# USAGE:
+#   paint <color> [text...]
+paint() {
+  local color=$1 rest=${@:2}
+  echo "$color$rest$reset"
+}
+
+# Aliases for common used colors
+# Colon at the end is required: https://askubuntu.com/a/521942
+# USAGE:
+#   info|warn|error|success|code [...text]
+info()    { paint "$cyan"   "Typewritten: $@" ; }
+warn()    { paint "$yellow" "Typewritten: $@" ; }
+error()   { paint "$red"    "Typewritten: $@" ; }
+success() { paint "$green"  "Typewritten: $@" ; }
+code()    { paint "$bold"   "Typewritten: $@" ; }
+
+# Check if symlink is exists and remove it
+# USAGE:
+#   rmln <target>
+rmln() {
+  local target=$1
+  if [[ -L "$target" ]]; then
+    info "Removing $target..."
+    rm -f "$target"
+  fi
+}
+
+# ------------------------------------------------------------------------------
+# MAIN
+# Checkings and uninstalling process
+# ------------------------------------------------------------------------------
+
+main() {
+  # Remove prompt setup symlink
+  if [[ -L "$GLOBAL_DEST_SETUP" || -L "$USER_DEST_SETUP" ]]; then
+    rmln "$GLOBAL_DEST_SETUP"
+    rmln "$USER_DEST_SETUP"
+  else
+    warn "Symlinks to Typewritten setup are not found."
+  fi
+
+  # Remove prompt async symlink
+  if [[ -L "$GLOBAL_DEST_ASYNC" || -L "$USER_DEST_ASYNC" ]]; then
+    rmln "$GLOBAL_DEST_ASYNC"
+    rmln "$USER_DEST_ASYNC"
+  else
+    warn "Symlinks to Typewritten async are not found."
+  fi
+
+  success "Done! Typewritten installation has been removed!"
+  info "Don't forget to remove Typewritten config lines in ~/.zshrc"
+  success "Please, reload your terminal."
+}
+
+main "$@"


### PR DESCRIPTION
Hi, this pull request started as for the [issue](https://github.com/reobin/typewritten/issues/111) I opened.
I cloned/forked the install script form [Spaceship-prompt](https://github.com/spaceship-prompt/spaceship-prompt/blob/master/scripts/install.sh) and used it as a template for this installer. I tested the installer, both before and afer the changes in my own computer, and everything seems to work perfectly, although more rigorous testing may be required.

This new script solves both issues I had with the old one, which were:
- `async.zsh` and `typewritten.zsh` were not symlinked at all, probably due to the folder it was trying to do so, did not exist.
- the script did not respect the $ZDOTDIR variable.

I hope this helps.
Code seems to be self explainatory, however I am open for comments and improvements.