### PR TITLE
fix: make pure_verbose show full path by default

### DIFF
--- a/typewritten.zsh
+++ b/typewritten.zsh
@@ -75,7 +75,7 @@ tw_get_displayed_wd() {
   local tw_displayed_wd="$tw_git_relative_wd"
 
   # The pure layout defaults to home relative working directory, but allows customization
-  if [[ "$TYPEWRITTEN_PROMPT_LAYOUT" = "pure" && "$TYPEWRITTEN_RELATIVE_PATH" = "" ]]; then
+  if [[ "$TYPEWRITTEN_PROMPT_LAYOUT" = pure* && "$TYPEWRITTEN_RELATIVE_PATH" = "" ]]; then
     tw_displayed_wd=$tw_home_relative_wd
   fi;
 


### PR DESCRIPTION
When 'TYPEWRITTEN_RELATIVE_PATH' is unset, the 'pure_verbose' layout
does not display the full path. This differs from the default behavior
of the 'pure' layout. As 'pure_verbose' is meant to be a 'pure' variant
with additional information, their default behavior should be the same.

Fixes #130

---

Here's a screenshot of the change compared to #130

![image](https://user-images.githubusercontent.com/1640737/154375142-6668925c-7bf8-4498-9f90-fb3cb1e474f0.png)
