### PR TITLE
docs: add wiki's contributing page to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,14 @@
 ## How to Contribute
 
-For information related to contributing to typewritten, please check out the [Contributing](https://github.com/reobin/typewritten/wiki/Contributing) section of the wiki.
+Pull requests are welcome in this repository.
+
+## Local installation
+
+The easiest way to use a local copy to test out changes is to use npm.
+
+1. fork the repository and clone it on your machine
+2. `cd` into it
+3. `npm install -g .`
+4. reload zsh: `zsh`
+
+Any change you make to the prompt will be active after reloading zsh.


### PR DESCRIPTION
As the wiki is no longer active, merge its contributing page into
CONTRIBUTING.md. Otherwise, the page's contents are inaccessible unless
one clones the wiki repo.

Fixes #132