### PR TITLE
docs: Add antigen plugin manager installation info

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,6 +50,10 @@ Note: If creating the symlinks is a problem, you can skip the step and set `ZSH_
 
 Add `antibody bundle reobin/typewritten` to your `.zshrc`.
 
+## antigen
+
+Add `antigen bundle reobin/typewritten@main` to your `.zshrc`.
+
 ## zgen
 
 Add `zgen load reobin/typewritten typewritten` to your `.zshrc`.


### PR DESCRIPTION
Add installation information for [antigen](https://github.com/zsh-users/antigen) plugin manager in docs.