### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,12 @@ Set `ZSH_THEME="typewritten"` in your `.zshrc` file.
 
 Note: If creating the symlinks is a problem, you can skip the step and set `ZSH_THEME="typewritten/typewritten"` instead.
 
+## Fig
+
+Install `Powerlevel10k` with [Fig](https://fig.io) in just one click.
+
+<a href="https://fig.io/plugins/other/zaw_zsh-users" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ## antibody
 
 Add `antibody bundle reobin/typewritten` to your `.zshrc`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,7 @@ Note: If creating the symlinks is a problem, you can skip the step and set `ZSH_
 
 ## Fig
 
-Install `Powerlevel10k` with [Fig](https://fig.io) in just one click.
+Install `zaw` with [Fig](https://fig.io) in just one click.
 
 <a href="https://fig.io/plugins/other/zaw_zsh-users" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,9 +48,9 @@ Note: If creating the symlinks is a problem, you can skip the step and set `ZSH_
 
 ## Fig
 
-Install `zaw` with [Fig](https://fig.io) in just one click.
+Install `typewritten` with [Fig](https://fig.io) in just one click.
 
-<a href="https://fig.io/plugins/other/zaw_zsh-users" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+<a href="https://fig.io/plugins/other/typewritten_reobin" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ## antibody
 


### PR DESCRIPTION
We recently listed `typewritten` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme.