### PR TITLE
Add Fig as an installation method

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,12 @@ Set `ZSH_THEME="typewritten"` in your `.zshrc` file.
 
 Note: If creating the symlinks is a problem, you can skip the step and set `ZSH_THEME="typewritten/typewritten"` instead.
 
+## Fig
+
+Install `typewritten` with [Fig](https://fig.io) in just one click.
+
+<a href="https://fig.io/plugins/other/typewritten_reobin" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ## antibody
 
 Add `antibody bundle reobin/typewritten` to your `.zshrc`.


### PR DESCRIPTION
We recently listed on `typewritten` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!